### PR TITLE
fixed container name typo

### DIFF
--- a/bash/force-sar.sh
+++ b/bash/force-sar.sh
@@ -68,5 +68,5 @@ do
 done
 
 # stop container
-docker stop force-container
-docker rm force-container
+docker stop force-sar-container
+docker rm force-sar-container


### PR DESCRIPTION
Needs to match name defined in docker run command